### PR TITLE
Use bootstrap's default font

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -11,14 +11,15 @@ body {
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",
-    "Roboto",
-    "Oxygen",
-    "Ubuntu",
-    "Cantarell",
-    "Fira Sans",
-    "Droid Sans",
+    Roboto,
     "Helvetica Neue",
-    sans-serif;
+    Arial,
+    "Noto Sans",
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    "Noto Color Emoji";
   font-size: $fontSize-s;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
no cambia en iOS, macOS, Windows.

Linux antes:

![image](https://user-images.githubusercontent.com/20487262/94227883-ef9ec080-fed1-11ea-95cb-1c8fc4d611f5.png)

Linux después:

![image](https://user-images.githubusercontent.com/20487262/94227862-e31a6800-fed1-11ea-9720-94a4954ef82d.png)
